### PR TITLE
[minor version update] Refactor and remove dead code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
+.DS_Store
 .vscode
 dist/
 node_modules/
-.DS_Store

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/erbium

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@
 (The MIT License)
 
 Copyright (c) 2017-2020 Tomasz Tarnowski <t.tarnowski90@gmail.com>
+Copyright (c) 2020      Charlie Karniol <charliekarniol@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,7 @@
 
 (The MIT License)
 
-Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
-Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) 2017-2020 Tomasz Tarnowski <t.tarnowski90@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,209 +1,189 @@
 # ts-sinon
 
-Sinon extension providing functions to:
-- stub all object methods 
-- stub interface
-- stub object constructor
+[`sinon`](https://github.com/sinonjs/sinon) extension providing functions to:
+
+- stub object methods
+- stub object constructors
+- stub interfaces
 
 ## Prerequisites
 
-1. You have a version of Node.js >= [v8.4.0](https://nodejs.org/en/download/)
-2. You have installed [Typescript](https://www.typescriptlang.org/index.html#download-links)
+- [Node.js](https://nodejs.org/en/download/) `>= 8.4.0`
+- [Typescript](https://www.typescriptlang.org/index.html#download-links)
 
 ## Installation
 
-`npm install --save-dev ts-sinon`
-or
-`yarn add --dev ts-sinon`
-
-## Object stubs example
-
-Importing stubObject function:
-
-- import single function:
-```javascript
-import { stubObject } from "ts-sinon";
+```sh
+npm install --save-dev ts-sinon
+# or
+yarn add --dev ts-sinon
 ```
 
-- import as part of sinon singleton:
-```javascript
-import * as sinon from "ts-sinon";
+## Object stubbing
 
-const stubObject = sinon.stubObject;
+### Importing
+
+Importing the `stubObject` function:
+
+- as a single function:
+
+```javascript
+import { stubObject } from 'ts-sinon';
 ```
+
+- as part of the module:
+
+```javascript
+import * as tsSinon from 'ts-sinon';
+
+const stubObject = tsSinon.stubObject;
+```
+
+### Examples
 
 Stub all object methods:
 
 ```javascript
-class Test {
+class MyClass {
     method() { return 'original' }
 }
 
-const test = new Test();
-const testStub = stubObject<Test>(test);
+const instance = new MyClass();
+const stub = stubObject(instance);
 
-testStub.method.returns('stubbed');
+stub.method.returns('stubbed');
 
-expect(testStub.method()).to.equal('stubbed');
+expect(stub.method()).to.equal('stubbed');
 ```
 
-Partial stub:
+Stub only some methods:
 
 ```javascript
-class Test {
+class MyClass {
     methodA() { return 'A: original' }
     methodB() { return 'B: original' }
 }
 
-const test = new Test();
-const testStub = stubObject<Test>(test, ['methodA']);
+const instance = new MyClass();
+const stub = stubObject(instance, ['methodA']);
 
-expect(testStub.methodA()).to.be.undefined;
-expect(testStub.methodB()).to.equal('B: original');
+expect(stub.methodA()).to.be.undefined;
+expect(stub.methodB()).to.equal('B: original');
 ```
 
-Stub with predefined return values (deprecated - see the deprecation note):
+## Object constructor stubbing
+
+### Importing
+
+Importing the `stubConstructor` function:
+
+- as a single function:
 
 ```javascript
-class Test {
-    method() { return 'original' }
-}
-
-const test = new Test();
-const testStub = stubObject<Test>(test, { method: 'stubbed' });
-
-expect(testStub.method()).to.equal('stubbed');
-```
-## Interface stubs example
-
-Importing stubInterface function:
-
-- import single function:
-```javascript
-import { stubInterface } from "ts-sinon";
+import { stubConstructor } from 'ts-sinon';
 ```
 
-- import as part of sinon singleton:
-```javascript
-import * as sinon from "ts-sinon";
+- as part of the module:
 
-const stubInterface = sinon.stubInterface;
+```javascript
+import * as tsSinon from 'ts-sinon';
+
+const stubConstructor = tsSinon.stubConstructor;
 ```
 
-Interface stub (stub all methods):
+### Examples
+
+Stub all object methods:
+
+- without passing predefined arguments to the constructor:
 
 ```javascript
-interface Test {
-    method(): string;
-}
-
-const testStub = stubInterface<Test>();
-
-expect(testStub.method()).to.be.undefined;
-
-testStub.method.returns('stubbed');
-
-expect(testStub.method()).to.equal('stubbed');
-```
-
-Interface stub with predefined return values (deprecated - see the deprecation note):
-
-```javascript
-interface Test {
-    method(): string;
-}
-
-const testStub = stubInterface<Test>({ method: 'stubbed' });
-
-expect(testStub.method()).to.equal('stubbed');
-```
-
-## Object constructor stub example
-
-Importing stubConstructor function:
-
-- import single function:
-```javascript
-import { stubConstructor } from "ts-sinon";
-```
-
-- import as part of sinon singleton:
-```javascript
-import * as sinon from "ts-sinon";
-
-const stubConstructor = sinon.stubConstructor;
-```
-
-Object constructor stub (stub all methods):
-
-- without passing predefined args to the constructor:
-```javascript
-class Test {
-    public someVar: number = 10;
+class MyClass {
+    public someVar: number = 42;
 
     method(): string {
-        return 'value';
+        return 'original';
     }
 }
+const stub = stubConstructor(MyClass);
+```
+```javascript
+// stub methods
+expect(stub.method()).to.be.undefined;
 
-// type will be guessed automatically
-const testStub = stubConstructor(Test);
+stub.method.returns('stubbed');
 
-expect(testStub.method()).to.be.undefined;
+expect(stub.method()).to.equal('stubbed');
+```
+```javascript
+// stub other properties
+expect(stub.someVar).to.equal(42);
 
-testStub.method.returns('stubbed');
+stub.someVar = 24;
 
-expect(testStub.method()).to.equal('stubbed');
-
-expect(testStub.someVar).to.equal(10);
-
-testStub.someVar = 20;
-
-expect(testStub.someVar).to.equal(20);
+expect(stub.someVar).to.equal(24);
 ```
 
-- with passing predefined args to the constructor:
-```javascript
-class Test {
-    constructor(public someVar: string, y: boolean) {}
+- by passing predefined arguments to the constructor:
 
-    // ...
+```javascript
+class MyClass {
+    constructor(public foobar: string, xyzzy: boolean) {}
 }
 
-// it won't allow to pass incorrect args
-const testStub = stubConstructor(Test, "someVar value", true);
+// only allows passing arguments of correct type
+const stub = stubConstructor(MyClass, 'string', true);
 
-expect(testStub.someVar).to.equal("someValue");
+expect(stub.foobar).to.equal('string');
+expect(stub.xyzzy).to.equal(true);
 ```
 
-## Method map argument deprecation note
+## Interface stubbing
 
-Due to a potential risk of overwriting return value type of stubbed method (that won't be caught by TypeScript compiler) I have decided to mark it as deprecated.
-Please look at the following example of type overwriting using method map:
+### Importing
+
+Importing the `stubInterface` function:
+
+- as a single function:
 
 ```javascript
-interface ITest {
-    method1(): void;
-    method2(num: number): string;
+import { stubInterface } from 'ts-sinon';
+```
+
+- as part of the module:
+
+```javascript
+import * as tsSinon from 'ts-sinon';
+
+const stubInterface = tsSinon.stubInterface;
+```
+
+### Examples
+
+Stub all interface methods:
+
+```javascript
+interface MyInterface {
+    method(): string;
 }
 
-const interfaceStub: ITest = stubInterface<ITest>({
-    method2: 12345
-});
+const stub = stubInterface<MyInterface>();
 
-// following expression will assign 12345 value of type number to v variable which is incorrect (it will compile without an error)
-const v: string = interfaceStub.method2(1);
+expect(stub.method()).to.be.undefined;
 
+stub.method.returns('stubbed');
+
+expect(stub.method()).to.equal('stubbed');
 ```
 
-## Sinon methods
+## Accessing Sinon functions
 
-By importing 'ts-sinon' you have access to all sinon methods.
+By importing `ts-sinon` you have access to all `sinon` functions.
 
 ```javascript
-import sinon, { stubInterface } from "ts-sinon";
+import sinon, { stubInterface } from 'ts-sinon';
 
-const functionStub = sinon.stub();
+const stub = sinon.stub();
 const spy = sinon.spy();
 // ...
 ```
@@ -211,27 +191,30 @@ const spy = sinon.spy();
 or
 
 ```javascript
-import * as tsSinon from "ts-sinon"
+import * as tsSinon from 'ts-sinon'
 
-const functionStub = tsSinon.default.stub();
+const stub = tsSinon.default.stub();
 const spy = tsSinon.default.spy();
-const tsStubInterface = tsSinon.stubInterface<T>();
+// ...
 
+const interfaceStub = tsSinon.stubInterface<T>();
 // ...
 ```
 
-## Packages
+## Testing
+
+```
+npm test
+```
+
+## References
 
 ##### Dependencies:
-1. [Microsoft/TypeScript](https://github.com/Microsoft/TypeScript)
-2. [TypeStrong/ts-node](https://github.com/TypeStrong/ts-node)
-3. [sinonjs/sinon](https://github.com/sinonjs/sinon)
+- [Microsoft/TypeScript](https://github.com/Microsoft/TypeScript)
+- [TypeStrong/ts-node](https://github.com/TypeStrong/ts-node)
+- [sinonjs/sinon](https://github.com/sinonjs/sinon)
 
-##### Dev Dependencies:
-4. [mochajs/mocha](https://github.com/mochajs/mocha)
-5. [chaijs/chai](https://github.com/chaijs/chai)
-6. [domenic/sinon-chai](https://github.com/domenic/sinon-chai)
-
-## Tests
-
-`npm test`
+##### Development dependencies:
+- [mochajs/mocha](https://github.com/mochajs/mocha)
+- [chaijs/chai](https://github.com/chaijs/chai)
+- [domenic/sinon-chai](https://github.com/domenic/sinon-chai)

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ expect(stub.someVar).to.equal(24);
 
 ```javascript
 class MyClass {
-    constructor(public foobar: string, xyzzy: boolean) {}
+    constructor(public foobar: string, public xyzzy: boolean) {}
 }
 
 // only allows passing arguments of correct type

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [`sinon`](https://github.com/sinonjs/sinon) extension providing functions to:
 
-- stub object methods
+- stub or replace object methods
 - stub object constructors
 - stub interfaces
+
+in Typescript.
 
 ## Prerequisites
 
@@ -19,7 +21,7 @@ npm install --save-dev ts-sinon
 yarn add --dev ts-sinon
 ```
 
-## Object stubbing
+## Object method stubbing
 
 ### Importing
 
@@ -69,6 +71,70 @@ const stub = stubObject(instance, ['methodA']);
 
 expect(stub.methodA()).to.be.undefined;
 expect(stub.methodB()).to.equal('B: original');
+```
+
+## Object method replacement
+
+`sinon` allows us to [replace object methods](https://sinonjs.org/releases/v8.1.1/stubs/#var-stub--sinonstubobject-method).
+
+### Importing
+
+Importing the `replaceObject` function:
+
+- as a single function:
+
+```javascript
+import { replaceObject } from 'ts-sinon';
+```
+
+- as part of the module:
+
+```javascript
+import * as tsSinon from 'ts-sinon';
+
+const replaceObject = tsSinon.replaceObject;
+```
+
+### Examples
+
+Replace all object methods:
+
+```javascript
+class MyClass {
+    method() { return 'original' }
+}
+
+const instance = new MyClass();
+const stub = replaceObject(instance);
+
+stub.method.returns('stubbed');
+
+// note: calling the instance instead of the stub
+expect(instance.method()).to.equal('stubbed');
+
+stub.restore();
+
+expect(instance.method()).to.equal('original');
+```
+
+Replace only some methods:
+
+```javascript
+class MyClass {
+    methodA() { return 'A: original' }
+    methodB() { return 'B: original' }
+}
+
+const instance = new MyClass();
+const stub = replaceObject(instance, ['methodA']);
+
+// note: calling the instance instead of the stub
+expect(instance.methodA()).to.be.undefined;
+expect(instance.methodB()).to.equal('B: original');
+
+stub.restore();
+
+expect(instance.methodA()).to.equal('A: original');
 ```
 
 ## Object constructor stubbing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.0.25",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.2.0",
+  "version": "1.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Sinon library extension to stub objects and interfaces in TypeScript",
   "author": {
     "name": "Tomasz Tarnowski",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Sinon library extension to stub objects and interfaces in TypeScript",
   "author": {
     "name": "Tomasz Tarnowski",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-sinon",
   "version": "1.0.25",
-  "description": "sinon library extension to stub whole object and interfaces",
+  "description": "Sinon library extension to stub objects and interfaces in TypeScript",
   "author": {
     "name": "Tomasz Tarnowski",
     "email": "t.tarnowski90@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.2.0",
+  "version": "1.0.25",
   "description": "Sinon library extension to stub objects and interfaces in TypeScript",
   "author": {
     "name": "Tomasz Tarnowski",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.0.25",
+  "version": "1.1.0",
   "description": "Sinon library extension to stub objects and interfaces in TypeScript",
   "author": {
     "name": "Tomasz Tarnowski",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -384,4 +384,130 @@ describe('ts-sinon', () => {
             }
         });
     });
+
+    describe('examples in readme', () => {
+        describe('object method stubbing', () => {
+            it('stub all object methods', () => {
+                class MyClass {
+                    method() { return 'original' }
+                }
+                
+                const instance = new MyClass();
+                const stub = stubObject(instance);
+                
+                stub.method.returns('stubbed');
+                
+                expect(stub.method()).to.equal('stubbed');
+            });
+
+            it('stub only some methods', () => {
+                class MyClass {
+                    methodA() { return 'A: original' }
+                    methodB() { return 'B: original' }
+                }
+                
+                const instance = new MyClass();
+                const stub = stubObject(instance, ['methodA']);
+                
+                expect(stub.methodA()).to.be.undefined;
+                expect(stub.methodB()).to.equal('B: original');
+            });
+        });
+
+        describe('object method replacement', () => {
+            it('replace all object methods', () => {
+                class MyClass {
+                    method() { return 'original' }
+                }
+                
+                const instance = new MyClass();
+                const stub = replaceObject(instance);
+                
+                stub.method.returns('stubbed');
+                
+                // note: calling the instance instead of the stub
+                expect(instance.method()).to.equal('stubbed');
+                
+                stub.restore();
+                
+                expect(instance.method()).to.equal('original');
+            });
+            
+            it('replace only some methods', () => {
+                class MyClass {
+                    methodA() { return 'A: original' }
+                    methodB() { return 'B: original' }
+                }
+                
+                const instance = new MyClass();
+                const stub = replaceObject(instance, ['methodA']);
+                
+                // note: calling the instance instead of the stub
+                expect(instance.methodA()).to.be.undefined;
+                expect(instance.methodB()).to.equal('B: original');
+                
+                stub.restore();
+                
+                expect(instance.methodA()).to.equal('A: original');
+            });
+        });
+
+        describe('object constructor stubbing', () => {
+            describe('stub all object methods', () => {
+                it('without passing predefined arguments to the constructor', () => {
+                    class MyClass {
+                        public someVar: number = 42;
+                    
+                        method(): string {
+                            return 'original';
+                        }
+                    }
+
+                    const stub = stubConstructor(MyClass);
+
+                    // stub methods
+                    expect(stub.method()).to.be.undefined;
+
+                    stub.method.returns('stubbed');
+
+                    expect(stub.method()).to.equal('stubbed');
+
+                    // stub other properties
+                    expect(stub.someVar).to.equal(42);
+
+                    stub.someVar = 24;
+
+                    expect(stub.someVar).to.equal(24);
+                });
+            
+                it('by passing predefined arguments to the constructor', () => {
+                    class MyClass {
+                        constructor(public foobar: string, public xyzzy: boolean) {}
+                    }
+                    
+                    // only allows passing arguments of correct type
+                    const stub = stubConstructor(MyClass, 'string', true);
+                    
+                    expect(stub.foobar).to.equal('string');
+                    expect(stub.xyzzy).to.equal(true);
+                });
+            });
+        });
+
+        describe('interface stubbing', () => {
+            it('stub all interface methods', () => {
+                interface MyInterface {
+                    method(): string;
+                }
+                
+                const stub = stubInterface<MyInterface>();
+                
+                expect(stub.method()).to.be.undefined;
+                
+                stub.method.returns('stubbed');
+                
+                expect(stub.method()).to.equal('stubbed');
+            });
+        });
+    });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,7 +1,7 @@
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 
-import { stubConstructor, stubInterface, stubObject } from './index';
+import { stubConstructor, stubInterface, stubObject, replaceObject } from './index';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -68,7 +68,7 @@ describe('ts-sinon', () => {
                 expect(stub.string).to.have.been.called;
             });
 
-            it(`allows to change am object literal stub values`, () => {
+            it(`allows to change an object literal stub values`, () => {
                 const object = {
                     number: () => {
                         return 42;
@@ -91,15 +91,11 @@ describe('ts-sinon', () => {
         describe('when methods list is given', () => {
             it('stubs given methods of an ES6 class', () => {
                 class MyClass {
-                    private s: string;
-                    constructor() {
-                        this.s = 'hi';
-                    }
                     number() {
                         return 42;
                     }
                     string() {
-                        return this.s;
+                        return 'hi';
                     }
                 }
                 
@@ -134,6 +130,169 @@ describe('ts-sinon', () => {
                 
                 expect(stub.number()).to.equal(24);
                 expect(stub.number).to.have.been.called;
+            });
+        });
+    });
+
+    describe(replaceObject.name, () => {
+        it('returned stub has restore property', () => {
+            const object = {};
+            const stub = replaceObject(object);
+            expect(typeof stub.restore).to.be.equal('function');
+        });
+
+        describe('when methods list is not given', () => {
+            it('replaces all methods of an ES6 class', () => {
+                class MyClass {
+                    number() {
+                        return 42;
+                    }
+                    string() {
+                        return 'hi';
+                    }
+                }
+
+                const object = new MyClass();
+                const stub = replaceObject(object);
+
+                expect(object.number()).to.be.undefined;
+                expect(object.string()).to.be.undefined;
+
+                stub.restore();
+
+                expect(object.number()).to.be.equal(42);
+                expect(object.string()).to.be.equal('hi');
+
+                expect(stub.string).to.have.been.calledOnce;
+                expect(stub.number).to.have.been.calledOnce;
+            });
+
+            it('allows to change ES6 class instance values', () => {
+                class MyClass {
+                    number() {
+                        return 42;
+                    }
+                    string() {
+                        return 'hi';
+                    }
+                }
+
+                const object = new MyClass();
+                const stub = replaceObject(object);
+
+                stub.number.returns(24);
+                stub.string.returns('bye');
+
+                expect(object.number()).to.equal(24);
+                expect(object.string()).to.equal('bye');
+
+                stub.restore();
+
+                expect(object.number()).to.be.equal(42);
+                expect(object.string()).to.be.equal('hi');
+
+                expect(stub.string).to.have.been.calledOnce;
+                expect(stub.number).to.have.been.calledOnce;
+            });
+
+            it('replaces all methods of an object literal', () => {
+                const object = {
+                    number: () => {
+                        return 42;
+                    },
+                    string: () => {
+                        return 'hi';
+                    }
+                };
+
+                const stub = replaceObject(object);
+
+                expect(object.number()).to.be.undefined;
+                expect(object.string()).to.be.undefined;
+
+                stub.restore();
+
+                expect(object.number()).to.be.equal(42);
+                expect(object.string()).to.be.equal('hi');
+
+                expect(stub.number).to.have.been.calledOnce;
+                expect(stub.string).to.have.been.calledOnce;
+            });
+
+            it(`allows to change an object literal stub values`, () => {
+                const object = {
+                    number: () => {
+                        return 42;
+                    },
+                    string: () => {
+                        return 'hi';
+                    }
+                }
+
+                const stub = replaceObject(object);
+
+                stub.number.returns(24);
+                stub.string.returns('bye');
+
+                expect(object.number()).to.equal(24);
+                expect(object.string()).to.equal('bye');
+
+                stub.restore();
+
+                expect(object.number()).to.be.equal(42);
+                expect(object.string()).to.be.equal('hi');
+
+                expect(stub.number).to.have.been.calledOnce;
+                expect(stub.string).to.have.been.calledOnce;
+            });
+        });
+
+        describe('when methods list is given', () => {
+            it('replaces given methods of an ES6 class', () => {
+                class MyClass {
+                    number() {
+                        return 42;
+                    }
+                    string() {
+                        return 'hi';
+                    }
+                }
+                
+                const object = new MyClass();
+                const stub = replaceObject(object, ['number']);
+    
+                expect(object.number()).to.be.undefined;
+                expect(object.string()).to.equal('hi');
+
+                stub.number.returns(24);
+
+                expect(object.number()).to.equal(24);
+                expect(object.string()).to.equal('hi');
+
+                expect(stub.number).to.have.been.calledTwice;
+            });
+    
+            it('replaces given methods of an object literal', () => {
+                const object = {
+                    number: () => {
+                        return 42;
+                    },
+                    string: () => {
+                        return 'hi';
+                    }
+                }
+                
+                const stub = replaceObject(object, ['number']);
+    
+                expect(object.number()).to.be.undefined;
+                expect(object.string()).to.equal('hi');
+
+                stub.number.returns(24);
+
+                expect(object.number()).to.equal(24);
+                expect(object.string()).to.equal('hi');
+
+                expect(stub.number).to.have.been.calledTwice;
             });
         });
     });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -9,7 +9,7 @@ chai.use(sinonChai);
 describe('ts-sinon', () => {
     describe(stubObject.name, () => {
         describe('when methods list is not given', () => {
-            it('stubs all methods of an ES6 object', () => {
+            it('stubs all methods of an ES6 class', () => {
                 class MyClass {
                     number() {
                         return 42;
@@ -29,7 +29,7 @@ describe('ts-sinon', () => {
                 expect(stub.number).to.have.been.called;
             });
 
-            it('allows to change ES6 object stub values', () => {
+            it(`allows to change ES6 class instance stub values`, () => {
                 class MyClass {
                     number() {
                         return 42;
@@ -49,7 +49,7 @@ describe('ts-sinon', () => {
                 expect(stub.string()).to.equal('bye');
             });
     
-            it('stubs all methods of a literal object', () => {
+            it('stubs all methods of an object literal', () => {
                 const object = {
                     number: () => {
                         return 42;
@@ -68,7 +68,7 @@ describe('ts-sinon', () => {
                 expect(stub.string).to.have.been.called;
             });
 
-            it('allows to change literal object stub values', () => {
+            it(`allows to change am object literal stub values`, () => {
                 const object = {
                     number: () => {
                         return 42;
@@ -89,7 +89,7 @@ describe('ts-sinon', () => {
         });
 
         describe('when methods list is given', () => {
-            it('stubs ES6 object partially', () => {
+            it('stubs given methods of an ES6 class', () => {
                 class MyClass {
                     private s: string;
                     constructor() {
@@ -115,7 +115,7 @@ describe('ts-sinon', () => {
                 expect(stub.number).to.have.been.called;
             });
     
-            it('stubs literal object partially', () => {
+            it('stubs given methods of an object literal', () => {
                 const object = {
                     number: () => {
                         return 42;
@@ -139,7 +139,7 @@ describe('ts-sinon', () => {
     });
 
     describe(stubConstructor.name, () => {
-        it('stubs all object constructor methods', () => {
+        it('stubs all methods using an ES6 class constructor', () => {
             class MyClass {
                 public greeting: string = 'hi';
                 constructor(private secret: string, public number: number) {}
@@ -174,8 +174,8 @@ describe('ts-sinon', () => {
 
     describe(stubInterface.name, () => {
         interface SomeInterface {
-            doSomething(): void;
             numberToString(n: number): string;
+            doSomething(): void;
         }
 
         it('stubs all methods of an object constructed from the interface', () => {
@@ -195,7 +195,7 @@ describe('ts-sinon', () => {
             expect(stub.doSomething).to.have.been.called;
         });
 
-        it('stubs method to return resolved Promise with another interface stub', async () => {
+        it(`stubs a method which returns a resolved Promise with another interface's stub`, async () => {
             interface MyInterface {
                 method(): Promise<SomeInterface>;
             }
@@ -208,7 +208,7 @@ describe('ts-sinon', () => {
             expect(await myStub.method()).to.equal(someStub);
         });
 
-        it('stubs method to return rejected Promise with another interface stub', async () => {
+        it(`stubs a method which returns a rejected Promise with another interface's stub`, async () => {
             interface MyInterface {
                 method(): Promise<SomeInterface>;
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,9 @@ export function stubObject<T extends object, K extends keyof T>(object: T, onlyT
     return stubbedObject;
 }
 
-type Restoreable<T> = StubbedInstance<T> & { restore(): void }
+export type ReplacedInstance<T> = StubbedInstance<T> & { restore(): void }
 
-export function replaceObject<T extends object, K extends keyof T>(object: T, onlyTheseMethods?: K[]): Restoreable<T> {
+export function replaceObject<T extends object, K extends keyof T>(object: T, onlyTheseMethods?: K[]): ReplacedInstance<T> {
     const stubbedObject = Object.assign(<sinon.SinonStubbedInstance<T>> {}, object);
     const objectPrototypeMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(object))
         .filter(attr => typeof object[attr] === 'function');

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export function stubObject<T extends object, K extends keyof T>(object: T, onlyT
     return stubbedObject;
 }
 
-export type ReplacedInstance<T> = StubbedInstance<T> & { restore(): void }
+export type ReplacedInstance<T> = sinon.SinonStubbedInstance<T> & T & { restore(): void }
 
 export function replaceObject<T extends object, K extends keyof T>(object: T, onlyTheseMethods?: K[]): ReplacedInstance<T> {
     const stubbedObject = Object.assign(<sinon.SinonStubbedInstance<T>> {}, object);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const excludedMethods: string[] = Object.getOwnPropertyNames(Object.getPrototype
 
 export type StubbedInstance<T> = sinon.SinonStubbedInstance<T> & T;
 
-export function stubObject<T extends object>(object: T, onlyTheseMethods?: string[]): StubbedInstance<T> {
+export function stubObject<T extends object, K extends keyof T>(object: T, onlyTheseMethods?: K[]): StubbedInstance<T> {
     const stubbedObject = Object.assign(<sinon.SinonStubbedInstance<T>> {}, object);
     const objectMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(object));
 
@@ -24,7 +24,7 @@ export function stubObject<T extends object>(object: T, onlyTheseMethods?: strin
 
     if (onlyTheseMethods && onlyTheseMethods.length > 0) {
         for (const method of onlyTheseMethods) {
-            stubbedObject[method] = sinon.stub();
+            stubbedObject[<string>method] = sinon.stub();
         }
     } else {
         for (const method of objectMethods) {
@@ -38,13 +38,13 @@ export function stubObject<T extends object>(object: T, onlyTheseMethods?: strin
 }
 
 export function stubConstructor<T extends new (...args: any[]) => any>(
-    constructor: T, ...constructorArgs: ConstructorParameters<T> | undefined[]
+    constructor: T, ...constructorArgs: ConstructorParameters<T>
 ): StubbedInstance<InstanceType<T>> {
     return stubObject(new constructor(...constructorArgs));
 }
 
 export function stubInterface<T extends object>(): StubbedInstance<T> {
-    const object = stubObject<T>(<T> {});
+    const object = stubObject(<T> {});
         
     const proxy = new Proxy(object, {
         get: (target, property) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,29 +14,29 @@ export function stubObject<T extends object>(object: T, methods?: string[] | obj
         'toString', 'valueOf', '__proto__', 'toLocaleString', 'isPrototypeOf'
     ];
 
-    for (let method in object) {
+    for (const method in object) {
         if (typeof object[method] == "function") {
             objectMethods.push(method);
         }
     }    
 
-    for (let method of objectMethods) {
+    for (const method of objectMethods) {
         if (!excludedMethods.includes(method)) {
             stubObject[method] = object[method];
         }
     }
 
     if (Array.isArray(methods)) {
-        for (let method of methods) {
+        for (const method of methods) {
             stubObject[method] = sinon.stub();
         }
     } else if (typeof methods == "object") {
-        for (let method in methods) {
+        for (const method in methods) {
             stubObject[method] = sinon.stub();
             stubObject[method].returns(methods[method]);
         }
     } else {
-        for (let method of objectMethods) {
+        for (const method of objectMethods) {
             if (typeof object[method] == "function" && method !== "constructor") {
                 stubObject[method] = sinon.stub();
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,71 +1,58 @@
-import * as sinon from "sinon";
+import * as sinon from 'sinon';
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#Methods_2
+const excludedMethods: string[] = Object.getOwnPropertyNames(Object.getPrototypeOf({}))
+    .filter(p => !['constructor', 'toSource'].includes(p));
 
 export type StubbedInstance<T> = sinon.SinonStubbedInstance<T> & T;
 
-/**
- * @param methods passing map of methods has become @deprecated as it may lead to overwriting stubbed method type
- */
-export function stubObject<T extends object>(object: T, methods?: string[] | object): StubbedInstance<T> {
-    const stubObject = Object.assign(<sinon.SinonStubbedInstance<T>> {}, object);
+export function stubObject<T extends object>(object: T, onlyTheseMethods?: string[]): StubbedInstance<T> {
+    const stubbedObject = Object.assign(<sinon.SinonStubbedInstance<T>> {}, object);
     const objectMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(object));
-    const excludedMethods: string[] = [
-        '__defineGetter__', '__defineSetter__', 'hasOwnProperty',
-        '__lookupGetter__', '__lookupSetter__', 'propertyIsEnumerable',
-        'toString', 'valueOf', '__proto__', 'toLocaleString', 'isPrototypeOf'
-    ];
 
     for (const method in object) {
-        if (typeof object[method] == "function") {
+        if (typeof object[method] === 'function') {
             objectMethods.push(method);
         }
-    }    
+    }
 
     for (const method of objectMethods) {
         if (!excludedMethods.includes(method)) {
-            stubObject[method] = object[method];
+            stubbedObject[method] = object[method];
         }
     }
 
-    if (Array.isArray(methods)) {
-        for (const method of methods) {
-            stubObject[method] = sinon.stub();
-        }
-    } else if (typeof methods == "object") {
-        for (const method in methods) {
-            stubObject[method] = sinon.stub();
-            stubObject[method].returns(methods[method]);
+    if (onlyTheseMethods && onlyTheseMethods.length > 0) {
+        for (const method of onlyTheseMethods) {
+            stubbedObject[method] = sinon.stub();
         }
     } else {
         for (const method of objectMethods) {
-            if (typeof object[method] == "function" && method !== "constructor") {
-                stubObject[method] = sinon.stub();
+            if (typeof object[method] === 'function' && method !== 'constructor') {
+                stubbedObject[method] = sinon.stub();
             }
         }
     }
-
-    return stubObject;
+    
+    return stubbedObject;
 }
 
 export function stubConstructor<T extends new (...args: any[]) => any>(
-    constructor: T,
-    ...constructorArgs: ConstructorParameters<T> | undefined[]
+    constructor: T, ...constructorArgs: ConstructorParameters<T> | undefined[]
 ): StubbedInstance<InstanceType<T>> {
     return stubObject(new constructor(...constructorArgs));
 }
 
-/**
- * @param methods passing map of methods has become @deprecated as it may lead to overwriting stubbed method type
- */
-export function stubInterface<T extends object>(methods: object = {}): StubbedInstance<T> {
-    const object = stubObject<T>(<T> {}, methods);
+export function stubInterface<T extends object>(): StubbedInstance<T> {
+    const object = stubObject<T>(<T> {});
         
     const proxy = new Proxy(object, {
-        get: (target, name) => {
-            if (!target[name] && name !== 'then') {
-                target[name] = sinon.stub();
+        get: (target, property) => {
+            if (!target[property] && property !== 'then') {
+                target[property] = sinon.stub();
             }
 
-            return target[name];
+            return target[property];
         }
     })
 
@@ -73,6 +60,7 @@ export function stubInterface<T extends object>(methods: object = {}): StubbedIn
 }
 
 sinon['stubObject'] = stubObject;
+sinon['stubConstructor'] = stubConstructor;
 sinon['stubInterface'] = stubInterface;
 
 export default sinon;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,9 @@
     "include": [
         "src/**/*.ts"
     ],
-    "exclude": ["node_modules", "dist", "./src/index.spec.ts"]
+    "exclude": [
+        "node_modules",
+        "dist", 
+        "./src/index.spec.ts"
+    ]
 }


### PR DESCRIPTION
### Motivation

I like the package and I want to use it regularly, but I don't like dead code. Old versions of the package can still be accessed via `npm` by pinning the version in `package.json`.

### Changes

  - Refactored and removed dead code
  - Updated `package.json` description, `README` and `LICENSE`
  - Small edits in config files

  - Added type safety for `stubObject` argument

  - Added `replaceObject`

<hr>

#### `stubObject`
  - `excludedMethods` moved out of the function and now uses exclusion of object prototype methods
  - passing objects as an argument is no longer supported
  - the argument accepts array of `keyof T` only, guaranteeing type safety

<hr>

#### `replaceObject`
  - new function implementing `sinon.stub(object, 'method')`

<hr>

#### `stubConstructor`
  - removed `undefined[]` from type of `constructorArgs`
  - extended `sinon['stubConstructor'] = stubConstructor;`

<hr>

### Next Steps

Publish to `npm`!