### PR TITLE
Enable ts-sinon to use sandboxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
-    "test": "./node_modules/.bin/mocha -r ts-node/register ./src/index.spec.ts"
+    "test": "./node_modules/.bin/mocha -r ts-node/register ./src/*.spec.ts"
   },
   "dependencies": {
     "@types/node": "^11.15.10",

--- a/src/ExtendedSandboxProxy.spec.ts
+++ b/src/ExtendedSandboxProxy.spec.ts
@@ -1,0 +1,375 @@
+import * as chai from "chai";
+import * as sinonChai from "sinon-chai";
+import * as sinon from "sinon";
+
+import { stubInterface } from "./index";
+import * as tsSinonLib from "./index";
+import { ExtendedSandboxProxy } from "./ExtendedSandboxProxy"
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('ExtendedSandboxProxy', function () {
+    let extendedSandboxProxy: ExtendedSandboxProxy
+    let sandboxStub: sinon.SinonSandbox
+
+    beforeEach(function () {
+        sandboxStub = stubInterface<sinon.SinonSandbox>()
+
+        extendedSandboxProxy = new ExtendedSandboxProxy(sandboxStub)
+    })
+
+    describe('.assert', function () {
+        let dummyAssertion: sinon.SinonAssert
+
+        beforeEach(function () {
+            dummyAssertion = stubInterface<sinon.SinonAssert>()
+        })
+
+        it('sets the objects assert property', function () {
+            extendedSandboxProxy.assert = dummyAssertion
+
+            expect(sandboxStub.assert).to.equal(dummyAssertion)
+        })
+
+        it('gets the objects assert property', function () {
+            sandboxStub.assert = dummyAssertion
+
+            expect(extendedSandboxProxy.assert).to.equal(dummyAssertion)
+        })
+    })
+
+    describe('.clock', function () {
+        let dummyClock: sinon.SinonFakeTimers
+
+        beforeEach(function () {
+            dummyClock = stubInterface<sinon.SinonFakeTimers>()
+        })
+
+        it('sets the objects clock property', function () {
+            extendedSandboxProxy.clock = dummyClock
+
+            expect(sandboxStub.clock).to.equal(dummyClock)
+        })
+
+        it('gets the objects clock property', function () {
+            sandboxStub.clock = dummyClock
+
+            expect(extendedSandboxProxy.clock).to.equal(dummyClock)
+        })
+    })
+
+    describe('.requests', function () {
+        let dummyRequests: sinon.SinonFakeXMLHttpRequest[]
+
+        beforeEach(function () {
+            dummyRequests = [stubInterface<sinon.SinonFakeXMLHttpRequest>()]
+        })
+
+        it('sets the objects requests property', function () {
+            extendedSandboxProxy.requests = dummyRequests
+
+            expect(sandboxStub.requests).to.equal(dummyRequests)
+        })
+
+        it('gets the objects requests property', function () {
+            sandboxStub.requests = dummyRequests
+
+            expect(extendedSandboxProxy.requests).to.equal(dummyRequests)
+        })
+    })
+
+    describe('.server', function () {
+        let dummyServer: sinon.SinonFakeServer
+
+        beforeEach(function () {
+            dummyServer = stubInterface<sinon.SinonFakeServer>()
+        })
+
+        it('sets the objects requests property', function () {
+            extendedSandboxProxy.server = dummyServer
+
+            expect(sandboxStub.server).to.equal(dummyServer)
+        })
+
+        it('gets the objects requests property', function () {
+            sandboxStub.server = dummyServer
+
+            expect(extendedSandboxProxy.server).to.equal(dummyServer)
+        })
+    })
+
+    describe('.spy', function () {
+        let dummySpy: sinon.SinonSpyStatic
+
+        beforeEach(function () {
+            dummySpy = stubInterface<sinon.SinonSpyStatic>()
+        })
+
+        it('sets the objects spy property', function () {
+            extendedSandboxProxy.spy = dummySpy
+
+            expect(sandboxStub.spy).to.equal(dummySpy)
+        })
+
+        it('gets the objects spy property', function () {
+            sandboxStub.spy = dummySpy
+
+            expect(extendedSandboxProxy.spy).to.equal(dummySpy)
+        })
+    })
+
+    describe('.stub', function () {
+        let dummyStub: sinon.SinonStubStatic
+
+        beforeEach(function () {
+            dummyStub = stubInterface<sinon.SinonStubStatic>()
+        })
+
+        it('sets the objects stub property', function () {
+            extendedSandboxProxy.stub = dummyStub
+
+            expect(sandboxStub.stub).to.equal(dummyStub)
+        })
+
+        it('gets the objects stub property', function () {
+            sandboxStub.stub = dummyStub
+
+            expect(extendedSandboxProxy.stub).to.equal(dummyStub)
+        })
+    })
+
+    describe('.mock', function () {
+        let dummyMock: sinon.SinonMockStatic
+
+        beforeEach(function () {
+            dummyMock = stubInterface<sinon.SinonMockStatic>()
+        })
+
+        it('sets the objects mock property', function () {
+            extendedSandboxProxy.mock = dummyMock
+
+            expect(sandboxStub.mock).to.equal(dummyMock)
+        })
+
+        it('gets the objects mock property', function () {
+            sandboxStub.mock = dummyMock
+
+            expect(extendedSandboxProxy.mock).to.equal(dummyMock)
+        })
+    })
+
+    describe('.useFakeTimers', function () {
+        const dummyConfig = 1000
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.useFakeTimers(dummyConfig)
+
+            expect(sandboxStub.useFakeTimers).to.be.calledWith(dummyConfig)
+        })
+    })
+
+    describe('.useFakeXMLHttpRequest', function () {
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.useFakeXMLHttpRequest()
+
+            expect(sandboxStub.useFakeXMLHttpRequest).to.be.called
+        })
+    })
+
+    describe('.useFakeServer', function () {
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.useFakeServer()
+
+            expect(sandboxStub.useFakeServer).to.be.called
+        })
+    })
+
+    describe('.restore', function () {
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.restore()
+
+            expect(sandboxStub.restore).to.be.called
+        })
+    })
+
+    describe('.reset', function () {
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.reset()
+
+            expect(sandboxStub.reset).to.be.called
+        })
+    })
+
+    describe('.resetHistory', function () {
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.resetHistory()
+
+            expect(sandboxStub.resetHistory).to.be.called
+        })
+    })
+
+    describe('.resetBehavior', function () {
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.resetBehavior()
+
+            expect(sandboxStub.resetBehavior).to.be.called
+        })
+    })
+
+    describe('.usingPromise', function () {
+        const dummyPromisLibrary = {}
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.usingPromise(dummyPromisLibrary)
+
+            expect(sandboxStub.usingPromise).to.be.calledWith(dummyPromisLibrary)
+        })
+    })
+
+    describe('.verify', function () {
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.verify()
+
+            expect(sandboxStub.verify).to.be.called
+        })
+    })
+
+    describe('.verifyAndRestore', function () {
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.verifyAndRestore()
+
+            expect(sandboxStub.verifyAndRestore).to.be.called
+        })
+    })
+
+    describe('.replace', function () {
+        const dummyObject = {
+            dummyAttribute: 'dummyAttribute'
+        }
+        const newDummyAttribute = 'newDummyAttribute'
+
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.replace(dummyObject, 'dummyAttribute', newDummyAttribute)
+
+            expect(sandboxStub.replace).to.be.calledWith(dummyObject, 'dummyAttribute', newDummyAttribute)
+        })
+    })
+
+    describe('.replaceGetter', function () {
+        class DummyClass {
+            public get dummyAttribute(): string {
+                return 'dummyAttribute'
+            }
+        }
+        const dummyClassObject = new DummyClass()
+        const newDummyAttributeGetter = () => 'newDummyAttribute'
+
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.replaceGetter(dummyClassObject, 'dummyAttribute', newDummyAttributeGetter)
+
+            expect(sandboxStub.replaceGetter).to.be.calledWith(dummyClassObject, 'dummyAttribute', newDummyAttributeGetter)
+        })
+    })
+
+    describe('.replaceSetter', function () {
+        class DummyClass {
+            public set dummyAttribute(_dummyAttribute: string) { }
+        }
+        const dummyClassObject = new DummyClass()
+        const newDummyAttributeSetter = () => { }
+
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.replaceSetter(dummyClassObject, 'dummyAttribute', newDummyAttributeSetter)
+
+            expect(sandboxStub.replaceSetter).to.be.calledWith(dummyClassObject, 'dummyAttribute', newDummyAttributeSetter)
+        })
+    })
+
+    describe('.createStubInstance', function () {
+        class DummyClass {
+            public dummyMethod(): any { }
+        }
+        const dummyOverrides = {
+            dummyMethod: sinon.stub()
+        }
+
+        it('calls the objects implementation', function () {
+            extendedSandboxProxy.createStubInstance(DummyClass, dummyOverrides)
+
+            expect(sandboxStub.createStubInstance).to.be.calledWith(DummyClass, dummyOverrides)
+        })
+    })
+
+    describe('.stubInterface', function () {
+        let stubInterfaceWithStubLibStub: sinon.SinonStub
+        interface DummyInterface {
+            dummyMethod(): () => void
+        }
+        const dummyMethods = {
+            dummyMethod: sinon.stub()
+        }
+
+        before(function () {
+            stubInterfaceWithStubLibStub = sinon.stub(tsSinonLib, 'stubInterfaceWithStubLib')
+        })
+
+        after(function () {
+            stubInterfaceWithStubLibStub.restore()
+        })
+
+        it('calls stubInterfaceWithStubLib with sandbox object', function () {
+            extendedSandboxProxy.stubInterface<DummyInterface>(dummyMethods)
+
+            expect(stubInterfaceWithStubLibStub).to.be.calledWith(sandboxStub, dummyMethods)
+        })
+    })
+
+    describe('.stubObject', function () {
+        let stubObjectWithStubLibStub: sinon.SinonStub
+        class DummyClass {
+            dummyMethod(): void { }
+        }
+        const dummyMethods = {
+            dummyMethod: sinon.stub()
+        }
+
+        before(function () {
+            stubObjectWithStubLibStub = sinon.stub(tsSinonLib, 'stubObjectWithStubLib')
+        })
+
+        after(function () {
+            stubObjectWithStubLibStub.restore()
+        })
+
+        it('calls stubObjectWithStubLib with sandbox object', function () {
+            const dummyObject = new DummyClass()
+            extendedSandboxProxy.stubObject(dummyObject, dummyMethods)
+
+            expect(stubObjectWithStubLibStub).to.be.calledWith(dummyObject, sandboxStub, dummyMethods)
+        })
+    })
+
+    describe('.stubConstructor', function () {
+        let stubConstructorWithStubLibStub: sinon.SinonStub
+        class DummyClass {
+            constructor(private argument) { }
+            dummyMethod(): void { }
+        }
+        const dummyMethods = {
+            dummyMethod: sinon.stub()
+        }
+
+        before(function () {
+            stubConstructorWithStubLibStub = sinon.stub(tsSinonLib, 'stubConstructorWithStubLib')
+        })
+
+        after(function () {
+            stubConstructorWithStubLibStub.restore()
+        })
+
+        it('calls stubObjectWithStubLib with sandbox object', function () {
+            extendedSandboxProxy.stubConstructor(DummyClass, dummyMethods)
+
+            expect(stubConstructorWithStubLibStub).to.be.calledWith(DummyClass, sandboxStub, dummyMethods)
+        })
+    })
+})

--- a/src/ExtendedSandboxProxy.ts
+++ b/src/ExtendedSandboxProxy.ts
@@ -1,0 +1,132 @@
+import { StubbedInstance, stubInterfaceWithStubLib, stubObjectWithStubLib, stubConstructorWithStubLib } from "./index";
+
+export class ExtendedSandboxProxy implements sinon.SinonSandbox {
+    public constructor(private sandbox: sinon.SinonSandbox) { }
+
+    public set assert(assert: sinon.SinonAssert) {
+        this.sandbox.assert = assert;
+    }
+
+    public get assert(): sinon.SinonAssert {
+        return this.sandbox.assert;
+    }
+
+    public set clock(clock: sinon.SinonFakeTimers) {
+        this.sandbox.clock = clock;
+    }
+
+    public get clock(): sinon.SinonFakeTimers {
+        return this.sandbox.clock;
+    }
+
+    public set requests(requests: sinon.SinonFakeXMLHttpRequest[]) {
+        this.sandbox.requests = requests;
+    }
+
+    public get requests(): sinon.SinonFakeXMLHttpRequest[] {
+        return this.sandbox.requests;
+    }
+
+    public set server(server: sinon.SinonFakeServer) {
+        this.sandbox.server = server;
+    }
+
+    public get server(): sinon.SinonFakeServer {
+        return this.sandbox.server;
+    }
+
+    public set spy(spy: sinon.SinonSpyStatic) {
+        this.sandbox.spy = spy;
+    }
+
+    public get spy(): sinon.SinonSpyStatic {
+        return this.sandbox.spy;
+    }
+
+    public set stub(stub: sinon.SinonStubStatic) {
+        this.sandbox.stub = stub;
+    }
+
+    public get stub(): sinon.SinonStubStatic {
+        return this.sandbox.stub;
+    }
+
+    public set mock(mock: sinon.SinonMockStatic) {
+        this.sandbox.mock = mock;
+    }
+
+    public get mock(): sinon.SinonMockStatic {
+        return this.sandbox.mock;
+    }
+
+    public useFakeTimers(config?: number | Date | Partial<sinon.SinonFakeTimersConfig>): sinon.SinonFakeTimers {
+        return this.sandbox.useFakeTimers(config);
+    }
+
+    public useFakeXMLHttpRequest(): sinon.SinonFakeXMLHttpRequestStatic {
+        return this.sandbox.useFakeXMLHttpRequest();
+    }
+
+    public useFakeServer(): sinon.SinonFakeServer {
+        return this.sandbox.useFakeServer();
+    }
+
+    public restore(): void {
+        this.sandbox.restore();
+    }
+
+    public reset(): void {
+        this.sandbox.reset();
+    }
+
+    public resetHistory(): void {
+        this.sandbox.resetHistory();
+    }
+
+    public resetBehavior(): void {
+        this.sandbox.resetBehavior();
+    }
+
+    public usingPromise(promiseLibrary: any): sinon.SinonSandbox {
+        return this.sandbox.usingPromise(promiseLibrary);
+    }
+
+    public verify(): void {
+        this.sandbox.verify();
+    }
+
+    public verifyAndRestore(): void {
+        this.sandbox.verifyAndRestore();
+    }
+
+    public replace<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: T[TKey]): T[TKey] {
+        return this.sandbox.replace(obj, prop, replacement);
+    }
+
+    public replaceGetter<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: () => T[TKey]): () => T[TKey] {
+        return this.sandbox.replaceGetter(obj, prop, replacement);
+    }
+
+    public replaceSetter<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: (val: T[TKey]) => void): (val: T[TKey]) => void {
+        return this.sandbox.replaceSetter(obj, prop, replacement);
+    }
+
+    public createStubInstance<TType>(constructor: sinon.StubbableType<TType>, overrides?: { [K in keyof TType]?: sinon.SinonStubbedMember<TType[K]> | (TType[K] extends (...args: any[]) => infer R ? R : TType[K]); }): sinon.SinonStubbedInstance<TType> {
+        return this.sandbox.createStubInstance(constructor, overrides);
+    }
+
+    public stubInterface<T extends object>(methods: object = {}): StubbedInstance<T> {
+        return stubInterfaceWithStubLib(this.sandbox, methods);
+    }
+
+    public stubObject<T extends object>(object: T, methods?: string[] | object): StubbedInstance<T> {
+        return stubObjectWithStubLib(object, this.sandbox, methods);
+    }
+
+    public stubConstructor<T extends new (...args: any[]) => any>(
+        constructor: T,
+        ...constructorArgs: ConstructorParameters<T> | undefined[]
+    ): StubbedInstance<InstanceType<T>> {
+        return stubConstructorWithStubLib(constructor, this.sandbox, ...constructorArgs);
+    }
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,7 +2,9 @@ import * as chai from "chai";
 import * as sinonChai from "sinon-chai";
 import * as sinon from "sinon";
 
-import { stubObject, stubInterface, stubConstructor, stubObjectWithStubLib, stubInterfaceWithStubLib, stubConstructorWithStubLib } from "./index";
+import { stubObject, stubInterface, stubConstructor, stubObjectWithStubLib, stubInterfaceWithStubLib, stubConstructorWithStubLib, createExtendedSandbox } from "./index";
+import { ExtendedSandboxProxy } from "./ExtendedSandboxProxy";
+import * as ExtendedSandboxProxyLib from "./ExtendedSandboxProxy";
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -320,4 +322,36 @@ describe('ts-sinon', () => {
             expect(dummyStubObject.dummyMethod).to.be.not.called
         })
     });
+
+    describe('createExtendedSandbox', function () {
+        let createSandboxStub: sinon.SinonStub;
+        let sandboxStubInstance: sinon.SinonStubbedInstance<sinon.SinonSandbox>
+        let extendedSandboxProxyStubInstance: sinon.SinonStubbedInstance<ExtendedSandboxProxy>;
+        let extendedSandboxProxyStub: sinon.SinonStub;
+
+        const config = {
+        } as Partial<sinon.SinonSandboxConfig>
+
+        before(function () {
+            sandboxStubInstance = stubInterface<sinon.SinonSandbox>();
+            createSandboxStub = sinon.stub(sinon, 'createSandbox');
+            createSandboxStub.returns(sandboxStubInstance);
+            extendedSandboxProxyStubInstance = sinon.createStubInstance(ExtendedSandboxProxy);
+            extendedSandboxProxyStub = sinon.stub(ExtendedSandboxProxyLib, 'ExtendedSandboxProxy');
+            extendedSandboxProxyStub.returns(extendedSandboxProxyStubInstance);
+        })
+
+        after(function () {
+            createSandboxStub.restore();
+            extendedSandboxProxyStub.restore();
+        })
+
+        it('creates a sinon sandbox and passes it to ExtendedSandboxProxy', function () {
+            const actualSandbox = createExtendedSandbox(config);
+
+            expect(createSandboxStub).to.be.calledWith(config);
+            expect(extendedSandboxProxyStub).to.be.calledWith(sandboxStubInstance);
+            expect(actualSandbox).to.equal(extendedSandboxProxyStubInstance);
+        })
+    })
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
 import * as sinon from "sinon";
 
 export type StubbedInstance<T> = sinon.SinonStubbedInstance<T> & T;
+export type StubLib = {
+    stub: sinon.SinonStubStatic
+}
 
 /**
  * @param methods passing map of methods has become @deprecated as it may lead to overwriting stubbed method type
  */
-export function stubObject<T extends object>(object: T, methods?: string[] | object): StubbedInstance<T> {
-    const stubObject = Object.assign(<sinon.SinonStubbedInstance<T>> {}, object);
+export function stubObjectWithStubLib<T extends object>(object: T, stubLib: StubLib, methods?: string[] | object): StubbedInstance<T> {
+    const stubObject = Object.assign(<sinon.SinonStubbedInstance<T>>{}, object);
     const objectMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(object));
     const excludedMethods: string[] = [
         '__defineGetter__', '__defineSetter__', 'hasOwnProperty',
@@ -18,7 +21,7 @@ export function stubObject<T extends object>(object: T, methods?: string[] | obj
         if (typeof object[method] == "function") {
             objectMethods.push(method);
         }
-    }    
+    }
 
     for (let method of objectMethods) {
         if (!excludedMethods.includes(method)) {
@@ -28,17 +31,17 @@ export function stubObject<T extends object>(object: T, methods?: string[] | obj
 
     if (Array.isArray(methods)) {
         for (let method of methods) {
-            stubObject[method] = sinon.stub();
+            stubObject[method] = stubLib.stub();
         }
     } else if (typeof methods == "object") {
         for (let method in methods) {
-            stubObject[method] = sinon.stub();
+            stubObject[method] = stubLib.stub();
             stubObject[method].returns(methods[method]);
         }
     } else {
         for (let method of objectMethods) {
             if (typeof object[method] == "function" && method !== "constructor") {
-                stubObject[method] = sinon.stub();
+                stubObject[method] = stubLib.stub();
             }
         }
     }
@@ -46,23 +49,38 @@ export function stubObject<T extends object>(object: T, methods?: string[] | obj
     return stubObject;
 }
 
+/**
+ * @param methods passing map of methods has become @deprecated as it may lead to overwriting stubbed method type
+ */
+export function stubObject<T extends object>(object: T, methods?: string[] | object): StubbedInstance<T> {
+    return stubObjectWithStubLib(object, sinon, methods);
+}
+
+export function stubConstructorWithStubLib<T extends new (...args: any[]) => any>(
+    constructor: T,
+    stubLib: StubLib,
+    ...constructorArgs: ConstructorParameters<T> | undefined[]
+): StubbedInstance<InstanceType<T>> {
+    return stubObjectWithStubLib(new constructor(...constructorArgs), stubLib);
+}
+
 export function stubConstructor<T extends new (...args: any[]) => any>(
     constructor: T,
     ...constructorArgs: ConstructorParameters<T> | undefined[]
 ): StubbedInstance<InstanceType<T>> {
-    return stubObject(new constructor(...constructorArgs));
+    return stubConstructorWithStubLib(constructor, sinon, ...constructorArgs)
 }
 
 /**
  * @param methods passing map of methods has become @deprecated as it may lead to overwriting stubbed method type
  */
-export function stubInterface<T extends object>(methods: object = {}): StubbedInstance<T> {
-    const object = stubObject<T>(<T> {}, methods);
-        
+export function stubInterfaceWithStubLib<T extends object>(stubLib: StubLib, methods: object = {}): StubbedInstance<T> {
+    const object = stubObjectWithStubLib<T>(<T>{}, stubLib, methods);
+
     const proxy = new Proxy(object, {
         get: (target, name) => {
             if (!target[name] && name !== 'then') {
-                target[name] = sinon.stub();
+                target[name] = stubLib.stub();
             }
 
             return target[name];
@@ -70,6 +88,13 @@ export function stubInterface<T extends object>(methods: object = {}): StubbedIn
     })
 
     return proxy;
+}
+
+/**
+ * @param methods passing map of methods has become @deprecated as it may lead to overwriting stubbed method type
+ */
+export function stubInterface<T extends object>(methods: object = {}): StubbedInstance<T> {
+    return stubInterfaceWithStubLib<T>(sinon, methods);
 }
 
 sinon['stubObject'] = stubObject;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import * as sinon from "sinon";
 
+import { ExtendedSandboxProxy } from "./ExtendedSandboxProxy"
+
 export type StubbedInstance<T> = sinon.SinonStubbedInstance<T> & T;
 export type StubLib = {
     stub: sinon.SinonStubStatic
@@ -97,7 +99,12 @@ export function stubInterface<T extends object>(methods: object = {}): StubbedIn
     return stubInterfaceWithStubLib<T>(sinon, methods);
 }
 
+export function createExtendedSandbox(config?: Partial<sinon.SinonSandboxConfig>): ExtendedSandboxProxy {
+    return new ExtendedSandboxProxy(sinon.createSandbox(config));
+}
+
 sinon['stubObject'] = stubObject;
 sinon['stubInterface'] = stubInterface;
+sinon['createExtendedSandbox'] = createExtendedSandbox;
 
 export default sinon;


### PR DESCRIPTION
By this PR the following is introduced:

1) every stub function has now an equivalent function that can take an additional parameter 
 - this parameter is used to stub
 - e.g. a sinon sandbox

2) a class is introduced that proxies a sinon sandbox
 - it also has methods for stubbing interfaces, objects and constructors

3) a factory function just like "createSandbox()" from sinon
 - this new factory function returns an instance of the new ProxyClass from point 2