### PR TITLE
Fix for class inheritence issue #137

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-sinon",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "sinon library extension to stub whole object and interfaces",
   "author": {
     "name": "Tomasz Tarnowski",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -284,7 +284,6 @@ describe('ts-sinon', () => {
         });
 
         it('stubs all object methods with inheritance', () => {
-          
           class B {
               methodB(): string {
                   return 'B';
@@ -302,7 +301,6 @@ describe('ts-sinon', () => {
           const expectedNewMethod2Value = 43;
           const expectedMethodBValue = 'new B value';
           const expectedMethod2Argument = 111;
-
 
           const stub = stubConstructor(A);
           

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -282,5 +282,43 @@ describe('ts-sinon', () => {
             expect(stub.method2(222)).to.equal(expectedNewMethod2Value);
             expect(stub.method2).to.have.been.calledWith(222);
         });
+
+        it('stubs all object methods with inheritance', () => {
+          
+          class B {
+              methodB(): string {
+                  return 'B';
+              }
+          }
+          class A extends B{             
+              method1(): string {
+                  return 'value1';
+              }
+              method2(x: number): number {
+                  return 13;
+              }
+          }
+          const expectedNewMethod1Value = 'new value';
+          const expectedNewMethod2Value = 43;
+          const expectedMethodBValue = 'new B value';
+          const expectedMethod2Argument = 111;
+
+
+          const stub = stubConstructor(A);
+          
+          expect(stub.method1()).to.be.undefined;
+          expect(stub.method2(expectedMethod2Argument)).to.be.undefined;
+          expect(stub.methodB()).to.be.undefined;
+
+          stub.method1.returns(expectedNewMethod1Value);
+          stub.method2.returns(expectedNewMethod2Value);
+          stub.methodB.returns(expectedMethodBValue);
+          expect(stub.method2).to.have.been.calledWith(expectedMethod2Argument);
+
+          expect(stub.method1()).to.equal(expectedNewMethod1Value);
+          expect(stub.method2(222)).to.equal(expectedNewMethod2Value);
+          expect(stub.methodB()).to.equal(expectedMethodBValue);
+          expect(stub.method2).to.have.been.calledWith(222);
+      });
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,9 @@ export function stubInterface<T extends object>(methods: ObjectMethodsMap<T> = {
 }
 
 function getObjectMethods(object: object): Array<string> {
-    let methods: Array<string> = [];
+    const methods: Array<string> = [];
     while ((object = Reflect.getPrototypeOf(object))) {
-        let keys = Reflect.ownKeys(object);
+        const keys = Reflect.ownKeys(object);
         keys.forEach((key) => {
             if (typeof key === 'string') {
               methods.push(key);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export type ObjectMethodsMap<T> = {
 
 export function stubObject<T extends object>(object: T, methods?: ObjectMethodsKeys<T> | ObjectMethodsMap<T>): StubbedInstance<T> {
     const stubObject = Object.assign(<sinon.SinonStubbedInstance<T>> {}, object);
-    const objectMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(object));
+    const objectMethods = getObjectMethods(object)
     const excludedMethods: string[] = [
         '__defineGetter__', '__defineSetter__', 'hasOwnProperty',
         '__lookupGetter__', '__lookupSetter__', 'propertyIsEnumerable',
@@ -73,6 +73,20 @@ export function stubInterface<T extends object>(methods: ObjectMethodsMap<T> = {
             return target[name];
         }
     })
+}
+
+function getObjectMethods(object: object): Array<string> {
+    let methods: Array<string> = [];
+    while ((object = Reflect.getPrototypeOf(object))) {
+        let keys = Reflect.ownKeys(object);
+        keys.forEach((key) => {
+            if (typeof key === 'string') {
+              methods.push(key);
+            }
+        });
+    }
+        
+    return methods;
 }
 
 sinon['stubObject'] = stubObject;


### PR DESCRIPTION
I've tried to resolve the issue described in ticket number #137.

It didn't work for transpilation greater than es5 because it couldn't get method names from inherited classes.

Could you please review it? Thanks!